### PR TITLE
Fix directory runtime RPC not accepting u128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,7 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-arithmetic",
+ "sp-core",
  "sp-runtime",
  "sp-std",
 ]

--- a/cli/src/rpc.rs
+++ b/cli/src/rpc.rs
@@ -103,7 +103,7 @@ where
 	C::Api: BabeApi<Block>,
 	C::Api: BlockBuilder<Block>,
 	C::Api: crml_cennzx_rpc::CennzxRuntimeApi<Block, AssetId, Balance, AccountId>,
-	C::Api: crml_sylo_directory_rpc::SyloDirectoryRuntimeApi<Block, Balance, AccountId>,
+	C::Api: crml_sylo_directory_rpc::SyloDirectoryRuntimeApi<Block, AccountId>,
 	C::Api: crml_sylo_listing_rpc::SyloListingRuntimeApi<Block, AccountId>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: prml_generic_asset_rpc::AssetMetaApi<Block, AssetId>,

--- a/crml/sylo/src/directory/rpc/runtime-api/Cargo.toml
+++ b/crml/sylo/src/directory/rpc/runtime-api/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 serde = { version = "1.0.102", optional = true, features = ["derive"] }
 codec = { version = "1.3.5", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 sp-api = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
+sp-core = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
 sp-std = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
 sp-runtime = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }
 sp-arithmetic = { git = "https://github.com/plugblockchain/plug-blockchain", rev = "2.0.2", default-features = false }

--- a/crml/sylo/src/directory/rpc/runtime-api/src/lib.rs
+++ b/crml/sylo/src/directory/rpc/runtime-api/src/lib.rs
@@ -2,6 +2,7 @@
 
 use codec::{Codec, Decode, Encode};
 use sp_arithmetic::traits::BaseArithmetic;
+use sp_core::U256;
 use sp_runtime::RuntimeDebug;
 
 /// A result of querying the Sylo directory
@@ -15,11 +16,10 @@ pub enum SyloDirectoryResult<AccountId> {
 
 sp_api::decl_runtime_apis! {
 	/// The RPC API to interact with Sylo stake tree
-	pub trait SyloDirectoryApi<Balance, AccountId> where
-		Balance: Codec + BaseArithmetic,
+	pub trait SyloDirectoryApi<AccountId> where
 		AccountId: Codec,
 	{
 		/// Scan the stake directory and select a weighted node
-		fn scan(point: Balance) -> SyloDirectoryResult<AccountId>;
+		fn scan(point: U256) -> SyloDirectoryResult<AccountId>;
 	}
 }

--- a/crml/sylo/src/directory/rpc/src/lib.rs
+++ b/crml/sylo/src/directory/rpc/src/lib.rs
@@ -62,12 +62,15 @@ where
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
 
-		// Accepts u256 but should only work on u128
+		// Accepts u256 but should only work on u128.
+		// This is because u128 has a bug upstream where they are not properly deserialised by the runtime.
+		// The suggested workaround for this is to accept a u256 and then do a checked cast into a u128.
+		// Therefore, reject any value that cannot be cast into a u128 here.
 		if point > u128::MAX.into() {
 			return Err(RpcError {
 				code: ErrorCode:: ServerError(Error::Runtime.into()),
 				message: "Value too large.".into(),
-				data: Some(format!("Expected a 128bit integer but received {:?} instead", point).into()), 
+				data: Some(format!("Expected a 128bit integer but received `{:?}` instead", point).into()),
 			})
 		}
 		let result = api.scan(&at, point).map_err(|e| RpcError {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -895,6 +895,10 @@ impl_runtime_apis! {
 
 	impl crml_sylo_directory_rpc_runtime_api::SyloDirectoryApi<Block, AccountId> for Runtime {
 		fn scan(point: U256) -> SyloDirectoryResult<AccountId> {
+			// Accepts u256 but should only work on u128.
+			// This is because u128 has a bug upstream where they are not properly deserialised by the runtime.
+			// The suggested workaround for this is to accept a u256 and then do a checked cast into a u128.
+			// It is assumed that the number can be converted into a u128 or else it would've been rejected.
 			let point: u128 = point.saturated_into();
 			let result = SyloDirectory::scan(point);
 			match result {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ use prml_generic_asset_rpc_runtime_api;
 use sp_api::impl_runtime_apis;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata, U256};
 use sp_runtime::{
 	create_runtime_str,
 	generic::{self, Era},
@@ -893,8 +893,9 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl crml_sylo_directory_rpc_runtime_api::SyloDirectoryApi<Block, Balance, AccountId> for Runtime {
-		fn scan(point: Balance) -> SyloDirectoryResult<AccountId> {
+	impl crml_sylo_directory_rpc_runtime_api::SyloDirectoryApi<Block, AccountId> for Runtime {
+		fn scan(point: U256) -> SyloDirectoryResult<AccountId> {
+			let point: u128 = point.saturated_into();
 			let result = SyloDirectory::scan(point);
 			match result {
 				Ok(acc) => SyloDirectoryResult::Success(acc),


### PR DESCRIPTION
Bug is upstream so for now a quick fix is to be applied.
Make the scan function take in a u256 instead.
Convert the u256 to a u128 instead.